### PR TITLE
ci: Confluence-Config als Secrets, Pro-Subscription-Auth, Scorecard-Fallback

### DIFF
--- a/.github/workflows/api-update-check.yml
+++ b/.github/workflows/api-update-check.yml
@@ -13,9 +13,6 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
-    # Gate only on the variable — secrets cannot be accessed in job-level if conditions.
-    # If CONFLUENCE_DOMAIN is set but CI_CONFLUENCE_TOKEN is missing, the step fails visibly.
-    if: ${{ vars.CONFLUENCE_DOMAIN != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -27,14 +24,31 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.REPO_PAT || github.token }}
 
+      # Domain and token are secrets (repo is public — secrets are masked in
+      # logs, variables are not). Secrets cannot be read in job-level `if`
+      # conditions, so gate via this preflight step instead.
+      - name: Preflight — check configuration
+        id: preflight
+        env:
+          CONFLUENCE_DOMAIN: ${{ secrets.CONFLUENCE_DOMAIN }}
+          CI_CONFLUENCE_TOKEN: ${{ secrets.CI_CONFLUENCE_TOKEN }}
+        run: |
+          if [ -z "$CONFLUENCE_DOMAIN" ] || [ -z "$CI_CONFLUENCE_TOKEN" ]; then
+            echo "::notice::Secrets CONFLUENCE_DOMAIN and/or CI_CONFLUENCE_TOKEN not configured — skipping API check."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check API schema
         id: check
+        if: steps.preflight.outputs.configured == 'true'
         env:
           # CI_CONFLUENCE_TOKEN should be a read-only token scoped to the minimum
           # required API endpoints — distinct from the full-backup CONFLUENCE_TOKEN.
           CONFLUENCE_TOKEN: ${{ secrets.CI_CONFLUENCE_TOKEN }}
-          CONFLUENCE_EMAIL: ${{ vars.CI_CONFLUENCE_EMAIL }}
-          CONFLUENCE_DOMAIN: ${{ vars.CONFLUENCE_DOMAIN }}
+          CONFLUENCE_EMAIL: ${{ secrets.CI_CONFLUENCE_EMAIL }}
+          CONFLUENCE_DOMAIN: ${{ secrets.CONFLUENCE_DOMAIN }}
         run: |
           set +e
           bash scripts/check-api-schema.sh
@@ -53,12 +67,13 @@ jobs:
             echo "snapshot_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Detect Anthropic API key
+      - name: Detect Claude credentials
         id: anthropic
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
-          if [ -n "$ANTHROPIC_API_KEY" ]; then
+          if [ -n "$ANTHROPIC_API_KEY" ] || [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
@@ -78,7 +93,10 @@ jobs:
         if: steps.check.outputs.exit_code == '1' && steps.anthropic.outputs.present == 'true'
         uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca  # v1
         with:
+          # Either secret works: ANTHROPIC_API_KEY (Console/pay-per-token) or
+          # CLAUDE_CODE_OAUTH_TOKEN (Pro/Max subscription via `claude setup-token`).
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             The daily Confluence API schema check detected drift. The diff between
             the stored baseline and the live API is in `drift.diff` (already in the

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,9 @@ jobs:
           results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: false
-          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          # SCORECARD_TOKEN (PAT) only improves the Branch-Protection check;
+          # all other checks work with the default token on public repos.
+          repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}
 
       - name: Upload SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v3 (2026-03-06)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,19 +79,23 @@ api-update-check (daily 06:00 UTC)
 ```
 
 - Baseline: `docs/api-snapshot.json` — committed via PR on first successful run
-- Script supports Basic Auth (set `CI_CONFLUENCE_EMAIL` var for ATATT tokens) or Bearer (ATSTT)
+- Script supports Basic Auth (set `CI_CONFLUENCE_EMAIL` secret for ATATT tokens) or Bearer (ATSTT)
+- Domain/token/email are **secrets**, not variables — repo is public, secrets are masked in logs
+- If neither CONFLUENCE_DOMAIN nor CI_CONFLUENCE_TOKEN secret is set, the job skips gracefully
 - Exit 2 (all endpoints unreachable) fails the job instead of writing an empty baseline
 
 ## Pending Manual Steps
 
-- Set SCORECARD_TOKEN secret (PAT with repo + read:org)
+- Set SCORECARD_TOKEN secret (optional — only improves Branch-Protection check)
 - Set COMMIT_SIGNING_PUBLIC_KEY secret (GPG key)
+- Set CONFLUENCE_DOMAIN secret (e.g. myorg.atlassian.net — for the daily API drift check)
 - Set CI_CONFLUENCE_TOKEN secret (read-only token for the daily API drift check)
-- Set CI_CONFLUENCE_EMAIL variable (only for ATATT personal tokens — Basic Auth)
-- Set ANTHROPIC_API_KEY secret (enables automatic code adaptation on API drift)
-- Set REPO_PAT secret (PAT with repo scope — lets drift PRs trigger CI and
-  auto-release tags trigger the release workflow)
-- Enable "Allow auto-merge" in repo settings (drift PRs merge once CI is green)
+- Set CI_CONFLUENCE_EMAIL secret (only for ATATT personal tokens — Basic Auth)
+- Set ANTHROPIC_API_KEY secret **or** CLAUDE_CODE_OAUTH_TOKEN secret (Pro/Max
+  subscription via `claude setup-token`) — enables automatic code adaptation on drift
+- Set REPO_PAT secret (PAT with repo + workflow scope — lets drift PRs trigger CI
+  and auto-release tags trigger the release workflow)
+- Enable "Allow auto-merge" in repo settings (snapshot-only drift PRs merge once CI is green)
 
 ## Extending: Adding a New Data Type
 


### PR DESCRIPTION
## Änderungen

**Domain als Secret statt Variable** — das Repo ist public; Actions-Variablen und Logs sind einsehbar, Secrets werden in Logs maskiert. Der Job wird jetzt über einen Preflight-Step gegated (Secrets sind in Job-level \`if\` nicht verfügbar) und **skippt sauber mit Hinweis**, solange \`CONFLUENCE_DOMAIN\`/\`CI_CONFLUENCE_TOKEN\` fehlen — statt rot fehlzuschlagen.

**Claude Pro/Max-Subscription-Support** — die claude-code-action akzeptiert jetzt alternativ \`CLAUDE_CODE_OAUTH_TOKEN\` (generiert mit \`claude setup-token\`), kein API-Key mit separater Abrechnung nötig.

**Scorecard-Fix** — läuft jetzt auch ohne \`SCORECARD_TOKEN\` (Fallback auf \`github.token\`; der PAT verbessert nur den Branch-Protection-Check). Gate über \`SCORECARD_ENABLED=true\` Variable bleibt.

## Benötigte Secrets (Settings → Secrets and variables → Actions)

| Secret | Zweck |
|--------|-------|
| \`CONFLUENCE_DOMAIN\` | z.B. \`myorg.atlassian.net\` |
| \`CI_CONFLUENCE_TOKEN\` | Read-only Confluence-Token für den Drift-Check |
| \`CI_CONFLUENCE_EMAIL\` | Nur bei ATATT-Personal-Token (Basic Auth) |
| \`CLAUDE_CODE_OAUTH_TOKEN\` **oder** \`ANTHROPIC_API_KEY\` | Automatische Code-Anpassung bei Drift |
| \`REPO_PAT\` | PAT mit repo+workflow Scope für die Auto-Release-Schlaufe |

🤖 Generated with [Claude Code](https://claude.com/claude-code)