### PR TITLE
ci: API-Check ohne Credentials via Atlassians öffentlicher OpenAPI-Spec

### DIFF
--- a/.github/workflows/api-update-check.yml
+++ b/.github/workflows/api-update-check.yml
@@ -13,9 +13,6 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
-    # Gate only on the variable — secrets cannot be accessed in job-level if conditions.
-    # If CONFLUENCE_DOMAIN is set but CI_CONFLUENCE_TOKEN is missing, the step fails visibly.
-    if: ${{ vars.CONFLUENCE_DOMAIN != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -27,21 +24,17 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.REPO_PAT || github.token }}
 
+      # The check compares Atlassian's published OpenAPI specs against the
+      # committed baseline — no Confluence instance or credentials needed.
       - name: Check API schema
         id: check
-        env:
-          # CI_CONFLUENCE_TOKEN should be a read-only token scoped to the minimum
-          # required API endpoints — distinct from the full-backup CONFLUENCE_TOKEN.
-          CONFLUENCE_TOKEN: ${{ secrets.CI_CONFLUENCE_TOKEN }}
-          CONFLUENCE_EMAIL: ${{ vars.CI_CONFLUENCE_EMAIL }}
-          CONFLUENCE_DOMAIN: ${{ vars.CONFLUENCE_DOMAIN }}
         run: |
           set +e
           bash scripts/check-api-schema.sh
           code=$?
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           if [ "$code" -gt 1 ]; then
-            echo "::error::check-api-schema.sh failed with exit code $code (API unreachable or token invalid)"
+            echo "::error::check-api-schema.sh failed with exit code $code (spec download failed)"
             exit "$code"
           fi
           # Detect a freshly created baseline (first run: script writes the
@@ -53,12 +46,13 @@ jobs:
             echo "snapshot_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Detect Anthropic API key
+      - name: Detect Claude credentials
         id: anthropic
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
-          if [ -n "$ANTHROPIC_API_KEY" ]; then
+          if [ -n "$ANTHROPIC_API_KEY" ] || [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
@@ -78,16 +72,18 @@ jobs:
         if: steps.check.outputs.exit_code == '1' && steps.anthropic.outputs.present == 'true'
         uses: anthropics/claude-code-action@0f97b95b6536c26e5f6bd90faec370d41695beca  # v1
         with:
+          # Either secret works: ANTHROPIC_API_KEY (Console/pay-per-token) or
+          # CLAUDE_CODE_OAUTH_TOKEN (Pro/Max subscription via `claude setup-token`).
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            The daily Confluence API schema check detected drift. The diff between
-            the stored baseline and the live API is in `drift.diff` (already in the
-            working tree), and `docs/api-snapshot.json` has been updated to the new
-            schema.
+            The daily Confluence API schema check detected drift between Atlassian's
+            published OpenAPI spec and the stored baseline. The diff is in
+            `drift.diff` (already in the working tree), and `docs/api-snapshot.json`
+            has been updated to the new schema.
 
             Adapt the tool to the API changes:
-            1. Read `drift.diff` to see which top-level fields were added/removed
-               per endpoint (spaces, pages, blogposts).
+            1. Read `drift.diff` to see which fields/endpoints were added or removed.
             2. Update the corresponding structs and fetch functions in
                `internal/api/confluence.go` so newly added fields are backed up
                and removed fields no longer break parsing.
@@ -133,7 +129,7 @@ jobs:
               if [ "$CLAUDE_RAN" = "true" ]; then
                 echo "Claude adapted \`internal/api/confluence.go\` to the changes; build and race tests passed."
               else
-                echo "**No ANTHROPIC_API_KEY configured** — only the snapshot was updated."
+                echo "**No Claude credentials configured** (ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN) — only the snapshot was updated."
                 echo "Review whether \`internal/api/confluence.go\` needs changes for the new fields."
               fi
               echo

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,9 @@ jobs:
           results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: false
-          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          # SCORECARD_TOKEN (PAT) only improves the Branch-Protection check;
+          # all other checks work with the default token on public repos.
+          repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}
 
       - name: Upload SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v3 (2026-03-06)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,10 @@ hierarchical directory structure with HMAC-SHA-256 signed manifest.
 ## Self-Update Loop (API drift)
 
 ```
-api-update-check (daily 06:00 UTC)
-  → drift detected → Claude adapts internal/api/confluence.go (needs ANTHROPIC_API_KEY)
+api-update-check (daily 06:00 UTC — no credentials needed)
+  → compares Atlassian's PUBLISHED OpenAPI specs against docs/api-snapshot.json
+  → drift detected → Claude adapts internal/api/confluence.go
+    (needs ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN)
   → PR with label api-drift (auto-merge only if snapshot-only;
     Go code changes always require human review — prompt-injection guard)
   → merge → auto-release bumps 0ver minor + pushes tag
@@ -78,20 +80,23 @@ api-update-check (daily 06:00 UTC)
     blocks while issues labeled `security` are open) → build → signed release
 ```
 
-- Baseline: `docs/api-snapshot.json` — committed via PR on first successful run
-- Script supports Basic Auth (set `CI_CONFLUENCE_EMAIL` var for ATATT tokens) or Bearer (ATSTT)
-- Exit 2 (all endpoints unreachable) fails the job instead of writing an empty baseline
+- The check uses Atlassian's public spec (dac-static.atlassian.com) — the API
+  definition is identical for every Confluence Cloud instance, so no instance,
+  domain, or token is required
+- Baseline: `docs/api-snapshot.json` (committed); sentinel `__ENDPOINT_MISSING__`
+  marks endpoints the tool calls that are no longer documented (currently:
+  templates_v1, space_property_v1 — candidates for v2 migration)
+- Exit 2 (spec download failed) fails the job; no snapshot is written
 
 ## Pending Manual Steps
 
-- Set SCORECARD_TOKEN secret (PAT with repo + read:org)
+- Set SCORECARD_TOKEN secret (optional — only improves Branch-Protection check)
 - Set COMMIT_SIGNING_PUBLIC_KEY secret (GPG key)
-- Set CI_CONFLUENCE_TOKEN secret (read-only token for the daily API drift check)
-- Set CI_CONFLUENCE_EMAIL variable (only for ATATT personal tokens — Basic Auth)
-- Set ANTHROPIC_API_KEY secret (enables automatic code adaptation on API drift)
-- Set REPO_PAT secret (PAT with repo scope — lets drift PRs trigger CI and
-  auto-release tags trigger the release workflow)
-- Enable "Allow auto-merge" in repo settings (drift PRs merge once CI is green)
+- Set ANTHROPIC_API_KEY secret **or** CLAUDE_CODE_OAUTH_TOKEN secret (Pro/Max
+  subscription via `claude setup-token`) — enables automatic code adaptation on drift
+- Set REPO_PAT secret (PAT with repo + workflow scope — lets drift PRs trigger CI
+  and auto-release tags trigger the release workflow)
+- Enable "Allow auto-merge" in repo settings (snapshot-only drift PRs merge once CI is green)
 
 ## Extending: Adding a New Data Type
 

--- a/docs/api-snapshot.json
+++ b/docs/api-snapshot.json
@@ -1,0 +1,126 @@
+{
+  "generated": "2026-06-12T15:10:37Z",
+  "sources": {
+    "v2": {
+      "url": "openapi-v2.v3.json",
+      "version": "2.0.0"
+    },
+    "v1": {
+      "url": "swagger.v3.json",
+      "version": "1.0.0"
+    }
+  },
+  "endpoints": {
+    "page_attachments": [
+      "_links",
+      "blogPostId",
+      "comment",
+      "createdAt",
+      "customContentId",
+      "downloadLink",
+      "fileId",
+      "fileSize",
+      "id",
+      "mediaType",
+      "mediaTypeDescription",
+      "pageId",
+      "status",
+      "title",
+      "version",
+      "webuiLink"
+    ],
+    "page_footer_comments": [
+      "_links",
+      "body",
+      "id",
+      "pageId",
+      "status",
+      "title",
+      "version"
+    ],
+    "page_inline_comments": [
+      "_links",
+      "body",
+      "id",
+      "pageId",
+      "properties",
+      "resolutionStatus",
+      "status",
+      "title",
+      "version"
+    ],
+    "space_blogposts": [
+      "_links",
+      "authorId",
+      "body",
+      "createdAt",
+      "id",
+      "spaceId",
+      "status",
+      "title",
+      "version"
+    ],
+    "space_pages": [
+      "_links",
+      "authorId",
+      "body",
+      "createdAt",
+      "id",
+      "lastOwnerId",
+      "ownerId",
+      "parentId",
+      "parentType",
+      "position",
+      "spaceId",
+      "status",
+      "subtype",
+      "title",
+      "version"
+    ],
+    "space_permissions": [
+      "id",
+      "operation",
+      "principal"
+    ],
+    "space_property_v1": [
+      "__ENDPOINT_MISSING__"
+    ],
+    "spaces": [
+      "_links",
+      "authorId",
+      "createdAt",
+      "currentActiveAlias",
+      "description",
+      "homepageId",
+      "icon",
+      "id",
+      "key",
+      "name",
+      "status",
+      "type"
+    ],
+    "templates_v1": [
+      "__ENDPOINT_MISSING__"
+    ],
+    "user_v1": [
+      "_expandable",
+      "_links",
+      "accountId",
+      "accountType",
+      "details",
+      "displayName",
+      "email",
+      "externalCollaborator",
+      "isExternalCollaborator",
+      "isGuest",
+      "operations",
+      "personalSpace",
+      "profilePicture",
+      "publicName",
+      "timeZone",
+      "type",
+      "userKey",
+      "username"
+    ]
+  }
+}

--- a/scripts/check-api-schema.sh
+++ b/scripts/check-api-schema.sh
@@ -1,97 +1,116 @@
 #!/usr/bin/env bash
 # check-api-schema.sh
 #
-# Hits Confluence Cloud API endpoints and extracts top-level JSON field names.
-# Writes the result to docs/api-snapshot.json.
+# Compares Atlassian's *published* Confluence Cloud OpenAPI specs against the
+# stored baseline (docs/api-snapshot.json). The API definition is identical
+# for every Confluence Cloud instance, so no instance, credentials, or
+# tokens are required — the check runs entirely against public documentation.
 #
-# Usage (local):
-#   # Personal account (Basic Auth, ATATT token):
-#   CONFLUENCE_EMAIL=user@example.com CONFLUENCE_TOKEN=<ATATT...> \
-#     CONFLUENCE_DOMAIN=myorg.atlassian.net ./scripts/check-api-schema.sh
-#   # Service account (Bearer, ATSTT token):
-#   CONFLUENCE_TOKEN=<ATSTT...> CONFLUENCE_DOMAIN=myorg.atlassian.net ./scripts/check-api-schema.sh
+# Tracked: every endpoint the tool actually calls (see internal/api/confluence.go).
+# Sentinel values in the snapshot:
+#   __ENDPOINT_MISSING__   — endpoint no longer documented (removed/deprecated)
+#   __SCHEMA_UNPARSEABLE__ — response schema shape changed beyond recognition
+#
+# Usage (local): ./scripts/check-api-schema.sh
 #
 # Exit codes:
-#   0 — no drift (or snapshot just created)
-#   1 — drift detected (CI should open an issue)
-#   2 — all endpoints unreachable (auth/network problem) — no snapshot written
+#   0 — no drift (or baseline just created)
+#   1 — drift detected (CI opens a PR)
+#   2 — spec download failed (network problem) — no snapshot written
 
 set -euo pipefail
 
-TOKEN="${CONFLUENCE_TOKEN:?CONFLUENCE_TOKEN must be set}"
-DOMAIN="${CONFLUENCE_DOMAIN:?CONFLUENCE_DOMAIN must be set}"
-EMAIL="${CONFLUENCE_EMAIL:-}"
-BASE="https://${DOMAIN}"
 SNAPSHOT="docs/api-snapshot.json"
-TMPFILE="$(mktemp)"
-trap 'rm -f "$TMPFILE"' EXIT
+UA="confluence-backup-api-check (+https://github.com/kAYd9iN/confluence-backup)"
+V2_URL="https://dac-static.atlassian.com/cloud/confluence/openapi-v2.v3.json"
+V1_URL="https://dac-static.atlassian.com/cloud/confluence/swagger.v3.json"
 
-# Confluence Cloud: personal ATATT tokens require Basic Auth (email:token);
-# Bearer only works for service-account ATSTT tokens (see issue #24).
-if [[ -n "$EMAIL" ]]; then
-  AUTH_ARGS=(-u "${EMAIL}:${TOKEN}")
-else
-  AUTH_ARGS=(-H "Authorization: Bearer ${TOKEN}")
-fi
+# Pick a python that actually runs (on Windows, `python3` may resolve to the
+# Microsoft Store alias stub, which only prints an install hint).
+PYTHON=""
+for candidate in python3 python; do
+  if "$candidate" -c "pass" >/dev/null 2>&1; then PYTHON="$candidate"; break; fi
+done
+[[ -n "$PYTHON" ]] || { echo "ERROR: no working python3 found" >&2; exit 2; }
 
-fetch_keys() {
-  local path="$1"
-  local response
-  response=$(curl -sf \
-    "${AUTH_ARGS[@]}" \
-    -H "Accept: application/json" \
-    --max-time 15 \
-    "${BASE}${path}") || { echo "WARN: ${BASE}${path} returned error — skipping" >&2; echo "[]"; return; }
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
 
-  # Confluence v2 list endpoints return { "results": [...], "_links": {...} }
-  # Extract keys from the first result item, or top-level keys for non-list responses.
-  echo "$response" | jq -r '
-    if .results | type == "array" and length > 0 then
-      .results[0] | keys
-    else
-      keys
-    end
-  ' 2>/dev/null || echo "[]"
+echo "Fetching published Confluence Cloud OpenAPI specs..." >&2
+# dac-static.atlassian.com rejects requests without a User-Agent header.
+curl -sf -A "$UA" --max-time 60 "$V2_URL" -o "$WORKDIR/v2.json" \
+  || { echo "ERROR: failed to download v2 spec ($V2_URL)" >&2; exit 2; }
+curl -sf -A "$UA" --max-time 60 "$V1_URL" -o "$WORKDIR/v1.json" \
+  || { echo "ERROR: failed to download v1 spec ($V1_URL)" >&2; exit 2; }
+
+"$PYTHON" - "$WORKDIR/v2.json" "$WORKDIR/v1.json" > "$WORKDIR/snapshot.json" <<'PY'
+import json, sys, datetime
+
+v2 = json.load(open(sys.argv[1], encoding="utf-8"))
+v1 = json.load(open(sys.argv[2], encoding="utf-8"))
+
+def deref(spec, obj, depth=0):
+    while isinstance(obj, dict) and "$ref" in obj and depth < 30:
+        target = spec
+        for part in obj["$ref"].lstrip("#/").split("/"):
+            target = target[part]
+        obj = target
+        depth += 1
+    return obj
+
+def fields(spec, path):
+    item = spec.get("paths", {}).get(path)
+    if not item or "get" not in item:
+        return ["__ENDPOINT_MISSING__"]
+    try:
+        schema = deref(spec, item["get"]["responses"]["200"]["content"]["application/json"]["schema"])
+        props = schema.get("properties", {})
+        # List endpoints wrap items in {results: [...], _links: {...}}
+        if "results" in props:
+            items = deref(spec, deref(spec, props["results"]).get("items", {}))
+            props = items.get("properties", {})
+        return sorted(props.keys()) or ["__SCHEMA_UNPARSEABLE__"]
+    except (KeyError, TypeError):
+        return ["__SCHEMA_UNPARSEABLE__"]
+
+# Every endpoint internal/api/confluence.go calls, mapped to its spec path.
+ENDPOINTS = {
+    "spaces":                ("v2", "/spaces"),
+    "space_pages":           ("v2", "/spaces/{id}/pages"),
+    "space_blogposts":       ("v2", "/spaces/{id}/blogposts"),
+    "space_permissions":     ("v2", "/spaces/{id}/permissions"),
+    "page_attachments":      ("v2", "/pages/{id}/attachments"),
+    "page_footer_comments":  ("v2", "/pages/{id}/footer-comments"),
+    "page_inline_comments":  ("v2", "/pages/{id}/inline-comments"),
+    "space_property_v1":     ("v1", "/wiki/rest/api/space/{spaceKey}/property"),
+    "templates_v1":          ("v1", "/wiki/rest/api/template"),
+    "user_v1":               ("v1", "/wiki/rest/api/user"),
 }
 
-declare -A PATHS=(
-  [spaces]="/wiki/api/v2/spaces?limit=1"
-  [pages]="/wiki/api/v2/pages?limit=1"
-  [blogposts]="/wiki/api/v2/blogposts?limit=1"
-)
+specs = {"v2": v2, "v1": v1}
+endpoints = {name: fields(specs[ver], path) for name, (ver, path) in sorted(ENDPOINTS.items())}
 
-echo "Fetching API schema from Confluence Cloud (${DOMAIN})..." >&2
-
-ENDPOINTS_JSON="{}"
-for name in "${!PATHS[@]}"; do
-  keys=$(fetch_keys "${PATHS[$name]}")
-  ENDPOINTS_JSON=$(echo "$ENDPOINTS_JSON" | jq --arg n "$name" --argjson k "$keys" '.[$n] = $k')
-  echo "  $name: $(echo "$keys" | jq -r 'length') fields" >&2
-done
-
-# If every endpoint failed (auth or network problem), do not write a bogus
-# empty baseline — that would mask real drift and corrupt drift detection.
-NONEMPTY=$(echo "$ENDPOINTS_JSON" | jq '[.[] | select(length > 0)] | length')
-if [[ "$NONEMPTY" -eq 0 ]]; then
-  echo "ERROR: all endpoints unreachable — check token/auth mode (CONFLUENCE_EMAIL for ATATT tokens)." >&2
-  exit 2
-fi
-
-NEW_SNAPSHOT=$(jq -n \
-  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --argjson ep "$ENDPOINTS_JSON" \
-  '{"generated": $ts, "endpoints": $ep | to_entries | sort_by(.key) | from_entries}')
-
-echo "$NEW_SNAPSHOT" > "$TMPFILE"
+print(json.dumps({
+    "generated": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "sources": {
+        "v2": {"url": "openapi-v2.v3.json", "version": v2.get("info", {}).get("version", "?")},
+        "v1": {"url": "swagger.v3.json", "version": v1.get("info", {}).get("version", "?")},
+    },
+    "endpoints": endpoints,
+}, indent=2))
+PY
 
 if [[ ! -f "$SNAPSHOT" ]]; then
-  cp "$TMPFILE" "$SNAPSHOT"
+  cp "$WORKDIR/snapshot.json" "$SNAPSHOT"
   echo "Snapshot created at $SNAPSHOT — no baseline existed yet." >&2
   exit 0
 fi
 
-OLD_EP=$(jq '.endpoints' "$SNAPSHOT")
-NEW_EP=$(jq '.endpoints' "$TMPFILE")
+extract_endpoints() {
+  "$PYTHON" -c "import json,sys; print(json.dumps(json.load(open(sys.argv[1], encoding='utf-8'))['endpoints'], indent=2, sort_keys=True))" "$1"
+}
+OLD_EP=$(extract_endpoints "$SNAPSHOT")
+NEW_EP=$(extract_endpoints "$WORKDIR/snapshot.json")
 
 if [[ "$OLD_EP" == "$NEW_EP" ]]; then
   echo "No API drift detected." >&2
@@ -99,7 +118,10 @@ if [[ "$OLD_EP" == "$NEW_EP" ]]; then
 fi
 
 echo "API DRIFT DETECTED:" >&2
-diff <(echo "$OLD_EP" | jq -S .) <(echo "$NEW_EP" | jq -S .) >&2 || true
-diff <(echo "$OLD_EP" | jq -S .) <(echo "$NEW_EP" | jq -S .) > drift.diff || true
+diff <(echo "$OLD_EP") <(echo "$NEW_EP") >&2 || true
+diff <(echo "$OLD_EP") <(echo "$NEW_EP") > drift.diff || true
+
+# Update the snapshot in place — CI commits it as part of the drift PR.
+cp "$WORKDIR/snapshot.json" "$SNAPSHOT"
 
 exit 1


### PR DESCRIPTION
## Kernidee (Feedback aus Review)

Die API-Definition ist für **alle** Confluence-Cloud-Instanzen identisch — eine spezifische Instanz mit Token abzufragen war unnötig. Der Check vergleicht jetzt Atlassians **öffentlich publizierte OpenAPI-Specs** (dac-static.atlassian.com) gegen eine committete Baseline.

**Ersetzt #39** (Secrets-Ansatz — wird obsolet).

### Vorteile

- **Keine Secrets nötig** für den Check (CONFLUENCE_DOMAIN/CI_CONFLUENCE_TOKEN/CI_CONFLUENCE_EMAIL entfallen komplett)
- **Abdeckung 3 → 10 Endpoints** — alle, die das Tool tatsächlich aufruft (inkl. Kommentare, Attachments, Permissions, v1-Legacy)
- **Baseline ist bereits committed** — Drift-Erkennung ist ab Merge sofort aktiv (kein Bootstrap-PR nötig)
- Lokal zweifach getestet: Baseline-Erstellung + Stabilität (kein False-Positive-Drift)

### ⚠️ Echte Befunde des ersten Laufs

Zwei v1-Endpoints, die das Tool nutzt, sind aus Atlassians Dokumentation **verschwunden** (als `__ENDPOINT_MISSING__` in der Baseline markiert):

| Endpoint | Im Tool | Status |
|----------|---------|--------|
| `/wiki/rest/api/template` | `FetchTemplates` | nicht mehr dokumentiert (nur noch `/template/page` + `/template/blueprint`) |
| `/wiki/rest/api/space/{key}/property` | Space-Properties | nach v2 migriert: `/spaces/{space-id}/properties` |

→ Kandidaten für v2-Migration, bevor Atlassian die v1-Endpoints abschaltet.

### Ausserdem

- claude-code-action akzeptiert `CLAUDE_CODE_OAUTH_TOKEN` (Pro/Max-Subscription) als Alternative zu `ANTHROPIC_API_KEY`
- Scorecard läuft ohne PAT (Fallback auf Standard-Token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)