### PR TITLE
api: Entfernte v1-Endpoints auf dokumentierte Ersatz-Endpoints migrieren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,7 @@ api-update-check (daily 06:00 UTC — no credentials needed)
   definition is identical for every Confluence Cloud instance, so no instance,
   domain, or token is required
 - Baseline: `docs/api-snapshot.json` (committed); sentinel `__ENDPOINT_MISSING__`
-  marks endpoints the tool calls that are no longer documented (currently:
-  templates_v1, space_property_v1 — candidates for v2 migration)
+  marks endpoints the tool calls that are no longer documented (currently: none)
 - Exit 2 (spec download failed) fails the job; no snapshot is written
 
 ## Pending Manual Steps

--- a/docs/api-snapshot.json
+++ b/docs/api-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-06-12T15:10:37Z",
+  "generated": "2026-06-12T15:31:52Z",
   "sources": {
     "v2": {
       "url": "openapi-v2.v3.json",
@@ -82,8 +82,13 @@
       "operation",
       "principal"
     ],
-    "space_property_v1": [
-      "__ENDPOINT_MISSING__"
+    "space_properties": [
+      "createdAt",
+      "createdBy",
+      "id",
+      "key",
+      "value",
+      "version"
     ],
     "spaces": [
       "_links",
@@ -99,8 +104,33 @@
       "status",
       "type"
     ],
-    "templates_v1": [
-      "__ENDPOINT_MISSING__"
+    "templates_blueprint_v1": [
+      "_expandable",
+      "_links",
+      "body",
+      "description",
+      "editorVersion",
+      "labels",
+      "name",
+      "originalTemplate",
+      "referencingBlueprint",
+      "space",
+      "templateId",
+      "templateType"
+    ],
+    "templates_page_v1": [
+      "_expandable",
+      "_links",
+      "body",
+      "description",
+      "editorVersion",
+      "labels",
+      "name",
+      "originalTemplate",
+      "referencingBlueprint",
+      "space",
+      "templateId",
+      "templateType"
     ],
     "user_v1": [
       "_expandable",

--- a/internal/api/confluence.go
+++ b/internal/api/confluence.go
@@ -159,8 +159,7 @@ func FetchSpaces(ctx context.Context, client *Client) ([]Space, error) {
 	return spaces, nil
 }
 
-// FetchSpaceDetail fetches permissions and properties for one space.
-// Uses both v2 (permissions) and v1 (properties) APIs.
+// FetchSpaceDetail fetches permissions and properties for one space (v2 API).
 func FetchSpaceDetail(ctx context.Context, client *Client, space Space) (SpaceDetail, error) {
 	detail := SpaceDetail{Space: space}
 
@@ -177,15 +176,15 @@ func FetchSpaceDetail(ctx context.Context, client *Client, space Space) (SpaceDe
 		}
 	}
 
-	// Properties (v1 — not yet in v2)
-	propBody, err := client.Get(ctx,
-		fmt.Sprintf("/wiki/rest/api/space/%s/property?expand=value,version&limit=200", space.Key))
+	// Properties (v2)
+	propItems, err := FetchAll(ctx, client,
+		fmt.Sprintf("/wiki/api/v2/spaces/%s/properties?limit=250", space.ID))
 	if err == nil {
-		var resp struct {
-			Results []SpaceProperty `json:"results"`
-		}
-		if json.Unmarshal(propBody, &resp) == nil {
-			detail.Properties = resp.Results
+		for _, raw := range propItems {
+			var p SpaceProperty
+			if json.Unmarshal(raw, &p) == nil {
+				detail.Properties = append(detail.Properties, p)
+			}
 		}
 	}
 	// Properties fetch failure is non-fatal — continue without them.
@@ -279,20 +278,26 @@ func FetchAttachmentMeta(ctx context.Context, client *Client, pageID string) ([]
 	return atts, nil
 }
 
-// FetchTemplates returns space-level templates (v1 API).
+// FetchTemplates returns space-level content and blueprint templates (v1 API).
+// The combined /wiki/rest/api/template endpoint is no longer documented;
+// /template/page and /template/blueprint replace it.
 func FetchTemplates(ctx context.Context, client *Client, spaceKey string) ([]Template, error) {
-	body, err := client.Get(ctx,
-		fmt.Sprintf("/wiki/rest/api/template?spaceKey=%s&limit=200", spaceKey))
-	if err != nil {
-		return nil, fmt.Errorf("fetch templates for space %s: %w", spaceKey, err)
+	var all []Template
+	for _, kind := range []string{"page", "blueprint"} {
+		body, err := client.Get(ctx,
+			fmt.Sprintf("/wiki/rest/api/template/%s?spaceKey=%s&limit=200", kind, spaceKey))
+		if err != nil {
+			return all, fmt.Errorf("fetch %s templates for space %s: %w", kind, spaceKey, err)
+		}
+		var resp struct {
+			Results []Template `json:"results"`
+		}
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return all, fmt.Errorf("parse %s templates for space %s: %w", kind, spaceKey, err)
+		}
+		all = append(all, resp.Results...)
 	}
-	var resp struct {
-		Results []Template `json:"results"`
-	}
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("parse templates: %w", err)
-	}
-	return resp.Results, nil
+	return all, nil
 }
 
 // FetchUserProfile fetches a single user profile by account ID (v1 API).

--- a/internal/api/confluence_test.go
+++ b/internal/api/confluence_test.go
@@ -115,6 +115,76 @@ func TestFetchPages_UsesStorageBodyFormat(t *testing.T) {
 	}
 }
 
+func TestFetchSpaceDetail_UsesV2PropertiesEndpoint(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if strings.HasSuffix(r.URL.Path, "/properties") {
+			json.NewEncoder(w).Encode(map[string]any{
+				"results": []map[string]any{
+					{"key": "theme", "value": map[string]any{"color": "blue"}, "version": map[string]any{"number": 1}},
+				},
+				"_links": map[string]any{},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{"results": []any{}, "_links": map[string]any{}})
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(srv.URL, "u@example.com", "tok")
+	detail, err := api.FetchSpaceDetail(context.Background(), c,
+		api.Space{ID: "123", Key: "KB"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, p := range paths {
+		if strings.Contains(p, "/wiki/rest/api/") {
+			t.Errorf("v1 endpoint must not be called, got: %s", p)
+		}
+		if p == "/wiki/api/v2/spaces/123/properties" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected v2 properties path /wiki/api/v2/spaces/123/properties, got: %v", paths)
+	}
+	if len(detail.Properties) != 1 || detail.Properties[0].Key != "theme" {
+		t.Errorf("unexpected properties: %+v", detail.Properties)
+	}
+}
+
+func TestFetchTemplates_UsesPageAndBlueprintEndpoints(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		var results []map[string]any
+		switch r.URL.Path {
+		case "/wiki/rest/api/template/page":
+			results = []map[string]any{{"templateId": "t1", "name": "Meeting Notes", "templateType": "page"}}
+		case "/wiki/rest/api/template/blueprint":
+			results = []map[string]any{{"templateId": "t2", "name": "Decision", "templateType": "blueprint"}}
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"results": results})
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(srv.URL, "u@example.com", "tok")
+	templates, err := api.FetchTemplates(context.Background(), c, "KB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 requests (page + blueprint), got %d: %v", len(paths), paths)
+	}
+	if len(templates) != 2 || templates[0].TemplateID != "t1" || templates[1].TemplateID != "t2" {
+		t.Errorf("unexpected templates: %+v", templates)
+	}
+}
+
 func TestValidateDomain(t *testing.T) {
 	if err := api.ValidateDomain("myorg.atlassian.net"); err != nil {
 		t.Errorf("valid domain rejected: %v", err)

--- a/scripts/check-api-schema.sh
+++ b/scripts/check-api-schema.sh
@@ -82,8 +82,9 @@ ENDPOINTS = {
     "page_attachments":      ("v2", "/pages/{id}/attachments"),
     "page_footer_comments":  ("v2", "/pages/{id}/footer-comments"),
     "page_inline_comments":  ("v2", "/pages/{id}/inline-comments"),
-    "space_property_v1":     ("v1", "/wiki/rest/api/space/{spaceKey}/property"),
-    "templates_v1":          ("v1", "/wiki/rest/api/template"),
+    "space_properties":      ("v2", "/spaces/{space-id}/properties"),
+    "templates_page_v1":     ("v1", "/wiki/rest/api/template/page"),
+    "templates_blueprint_v1": ("v1", "/wiki/rest/api/template/blueprint"),
     "user_v1":               ("v1", "/wiki/rest/api/user"),
 }
 


### PR DESCRIPTION
## Kontext

Der API-Schema-Check (`scripts/check-api-schema.sh`) hatte zwei v1-Endpoints als `__ENDPOINT_MISSING__` markiert — beide sind aus Atlassians publizierter OpenAPI-Spec verschwunden.

## Änderungen

**Space-Properties → v2** (`FetchSpaceDetail`)
- Vorher: `GET /wiki/rest/api/space/{key}/property?expand=value,version`
- Nachher: `GET /wiki/api/v2/spaces/{id}/properties` mit Cursor-Pagination via `FetchAll` (statt einer einzelnen Seite mit `limit=200`)
- `SpaceProperty` (key/value/version) passt unverändert auf das v2-Antwortschema
- Fehler bleiben wie bisher non-fatal

**Templates → /template/page + /template/blueprint** (`FetchTemplates`)
- Vorher: `GET /wiki/rest/api/template?spaceKey=…` (kombinierter Endpoint, nicht mehr dokumentiert)
- Nachher: je ein Aufruf von `/wiki/rest/api/template/page` und `/wiki/rest/api/template/blueprint`, Ergebnisse kombiniert — Blueprint-Templates werden damit jetzt mitgesichert

**Schema-Check**
- Endpoint-Map im Skript auf die neuen Pfade umgestellt (`space_properties` v2, `templates_page_v1`, `templates_blueprint_v1`)
- `docs/api-snapshot.json` regeneriert — keine Sentinel-Einträge mehr; alle neuen Endpoints liefern echte Schemafelder, die zu den Go-Structs passen
- CLAUDE.md-Hinweis auf die Migrations-Kandidaten entfernt

## Tests

- Zwei neue Tests: `TestFetchSpaceDetail_UsesV2PropertiesEndpoint` (verifiziert v2-Pfad, kein v1-Aufruf, Property-Decoding) und `TestFetchTemplates_UsesPageAndBlueprintEndpoints`
- `go vet ./...` und `go test -cover ./...` lokal grün für `internal/api` und `internal/backup`; `-race` läuft lokal unter Windows nicht (kein cgo/C-Compiler) und wird vom CI abgedeckt. Der vorbestehende Windows-Fail `TestWriter_WriteFile_Permissions` (0600 vs. 666) ist unabhängig von diesem PR.
- `./scripts/check-api-schema.sh` nach der Snapshot-Aktualisierung: „No API drift detected"

## Hinweis

Basiert auf `ci/spec-based-api-check` (#40), da Endpoint-Map und Snapshot erst dort existieren — bitte #40 zuerst mergen; GitHub retargetet diesen PR dann automatisch auf `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)