### PR TITLE
feat: Labels, Tasks, Custom Content und Smart-Content-Metadaten sichern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
 # confluence-backup — v0.3.0 (2026-03-09)
 
 Backup tool for Confluence Cloud. Backs up spaces, pages (HTML storage format), blog posts,
-comments, attachments, templates, users, and space permissions into a
-hierarchical directory structure with HMAC-SHA-256 signed manifest.
+comments, attachments, templates, users, space permissions, labels, inline tasks,
+custom content, and smart content metadata (whiteboards, databases, folders, embeds)
+into a hierarchical directory structure with HMAC-SHA-256 signed manifest.
 
 ## Commands
 
@@ -48,6 +49,11 @@ hierarchical directory structure with HMAC-SHA-256 signed manifest.
 - **Hierarchical output**: `spaces/KEY/pages/Title/SubTitle/index.html`
 - **Backup dir timestamp**: local timezone (not UTC)
 - **Attachments**: metadata always; files only with --attachments flag
+- **Smart content** (whiteboards, databases, folders, embeds): no v2 list
+  endpoints — discovered per space via v1 CQL search, fetched by ID;
+  **metadata only** (canvas/database contents are not exportable via API)
+- **Labels/tasks/custom content**: per space as labels.json, tasks.json,
+  custom-content.json (only written when non-empty)
 - **HMAC key**: domain-separated (confluence-backup-manifest\x00)
 - **vendor/**: checked in for supply-chain safety
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ in eine hierarchische Verzeichnisstruktur mit HMAC-SHA-256-signiertem Manifest.
 
 ## Features
 
-- Sichert 8 Confluence-Datentypen (GET-only, kein Schreibzugriff)
+- Sichert 12 Confluence-Datentypen inkl. Labels, Tasks, Custom Content und Smart-Content-Metadaten — Whiteboards, Databases, Folders, Embeds (GET-only, kein Schreibzugriff)
 - SHA256-Hashes pro Datei + HMAC-SHA-256-Manifest-Signatur
 - Zweistufiger Worker Pool (3 Spaces × 20 Pages global), Rate-Limiter (10 req/s)
 - Hierarchische Ausgabe: `spaces/KEY/pages/Titel/Untertitel/index.html`

--- a/docs/api-snapshot.json
+++ b/docs/api-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-06-12T15:31:52Z",
+  "generated": "2026-06-12T21:27:04Z",
   "sources": {
     "v2": {
       "url": "openapi-v2.v3.json",
@@ -11,6 +11,52 @@
     }
   },
   "endpoints": {
+    "database": [
+      "_links",
+      "authorId",
+      "createdAt",
+      "id",
+      "ownerId",
+      "parentId",
+      "parentType",
+      "position",
+      "spaceId",
+      "status",
+      "title",
+      "type",
+      "version"
+    ],
+    "embed": [
+      "_links",
+      "authorId",
+      "createdAt",
+      "embedUrl",
+      "id",
+      "ownerId",
+      "parentId",
+      "parentType",
+      "position",
+      "spaceId",
+      "status",
+      "title",
+      "type",
+      "version"
+    ],
+    "folder": [
+      "_links",
+      "authorId",
+      "createdAt",
+      "id",
+      "ownerId",
+      "parentId",
+      "parentType",
+      "position",
+      "spaceId",
+      "status",
+      "title",
+      "type",
+      "version"
+    ],
     "page_attachments": [
       "_links",
       "blogPostId",
@@ -49,6 +95,22 @@
       "title",
       "version"
     ],
+    "search_v1": [
+      "breadcrumbs",
+      "content",
+      "entityType",
+      "excerpt",
+      "friendlyLastModified",
+      "iconCssClass",
+      "lastModified",
+      "resultGlobalContainer",
+      "resultParentContainer",
+      "score",
+      "space",
+      "title",
+      "url",
+      "user"
+    ],
     "space_blogposts": [
       "_links",
       "authorId",
@@ -59,6 +121,31 @@
       "status",
       "title",
       "version"
+    ],
+    "space_content_labels": [
+      "id",
+      "name",
+      "prefix"
+    ],
+    "space_custom_content": [
+      "_links",
+      "authorId",
+      "blogPostId",
+      "body",
+      "createdAt",
+      "customContentId",
+      "id",
+      "pageId",
+      "spaceId",
+      "status",
+      "title",
+      "type",
+      "version"
+    ],
+    "space_labels": [
+      "id",
+      "name",
+      "prefix"
     ],
     "space_pages": [
       "_links",
@@ -103,6 +190,22 @@
       "name",
       "status",
       "type"
+    ],
+    "tasks": [
+      "assignedTo",
+      "blogPostId",
+      "body",
+      "completedAt",
+      "completedBy",
+      "createdAt",
+      "createdBy",
+      "dueAt",
+      "id",
+      "localId",
+      "pageId",
+      "spaceId",
+      "status",
+      "updatedAt"
     ],
     "templates_blueprint_v1": [
       "_expandable",
@@ -151,6 +254,21 @@
       "type",
       "userKey",
       "username"
+    ],
+    "whiteboard": [
+      "_links",
+      "authorId",
+      "createdAt",
+      "id",
+      "ownerId",
+      "parentId",
+      "parentType",
+      "position",
+      "spaceId",
+      "status",
+      "title",
+      "type",
+      "version"
     ]
   }
 }

--- a/internal/api/confluence.go
+++ b/internal/api/confluence.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"regexp"
 )
 
@@ -138,6 +139,40 @@ type User struct {
 	DisplayName string `json:"displayName"`
 	Email       string `json:"email"`
 	AccountType string `json:"accountType"`
+}
+
+// SpaceLabels groups space-level labels and labels used on content in the space.
+type SpaceLabels struct {
+	Space   []Label `json:"space"`
+	Content []Label `json:"content"`
+}
+
+// Task is an inline task (action item) from pages or blog posts.
+type Task struct {
+	ID          string `json:"id"`
+	LocalID     string `json:"localId,omitempty"`
+	SpaceID     string `json:"spaceId,omitempty"`
+	PageID      string `json:"pageId,omitempty"`
+	BlogPostID  string `json:"blogPostId,omitempty"`
+	Status      string `json:"status"`
+	CreatedBy   string `json:"createdBy,omitempty"`
+	AssignedTo  string `json:"assignedTo,omitempty"`
+	CompletedBy string `json:"completedBy,omitempty"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	DueAt       string `json:"dueAt,omitempty"`
+	CompletedAt string `json:"completedAt,omitempty"`
+	Body        struct {
+		Storage struct {
+			Value string `json:"value"`
+		} `json:"storage"`
+	} `json:"body"`
+}
+
+// ContentRef identifies a content item found via CQL search.
+type ContentRef struct {
+	ID    string `json:"id"`
+	Type  string `json:"type"`
+	Title string `json:"title"`
 }
 
 // --- Fetch functions ---
@@ -298,6 +333,134 @@ func FetchTemplates(ctx context.Context, client *Client, spaceKey string) ([]Tem
 		all = append(all, resp.Results...)
 	}
 	return all, nil
+}
+
+// FetchSpaceLabels returns space-level labels and content labels for a space.
+func FetchSpaceLabels(ctx context.Context, client *Client, spaceID string) (SpaceLabels, error) {
+	var sl SpaceLabels
+
+	spaceItems, err := FetchAll(ctx, client,
+		fmt.Sprintf("/wiki/api/v2/spaces/%s/labels?limit=250", spaceID))
+	if err != nil {
+		return sl, fmt.Errorf("fetch space labels for space %s: %w", spaceID, err)
+	}
+	for _, raw := range spaceItems {
+		var l Label
+		if json.Unmarshal(raw, &l) == nil {
+			sl.Space = append(sl.Space, l)
+		}
+	}
+
+	contentItems, err := FetchAll(ctx, client,
+		fmt.Sprintf("/wiki/api/v2/spaces/%s/content/labels?limit=250", spaceID))
+	if err != nil {
+		return sl, fmt.Errorf("fetch content labels for space %s: %w", spaceID, err)
+	}
+	for _, raw := range contentItems {
+		var l Label
+		if json.Unmarshal(raw, &l) == nil {
+			sl.Content = append(sl.Content, l)
+		}
+	}
+
+	return sl, nil
+}
+
+// FetchTasks returns all inline tasks in a space.
+func FetchTasks(ctx context.Context, client *Client, spaceID string) ([]Task, error) {
+	items, err := FetchAll(ctx, client,
+		fmt.Sprintf("/wiki/api/v2/tasks?space-id=%s&body-format=storage&limit=250", spaceID))
+	if err != nil {
+		return nil, fmt.Errorf("fetch tasks for space %s: %w", spaceID, err)
+	}
+	tasks := make([]Task, 0, len(items))
+	for _, raw := range items {
+		var t Task
+		if err := json.Unmarshal(raw, &t); err == nil {
+			tasks = append(tasks, t)
+		}
+	}
+	return tasks, nil
+}
+
+// FetchCustomContent returns custom content (app-defined types) in a space.
+// The payload shape is app-specific, so items are kept as raw JSON.
+func FetchCustomContent(ctx context.Context, client *Client, spaceID string) ([]json.RawMessage, error) {
+	items, err := FetchAll(ctx, client,
+		fmt.Sprintf("/wiki/api/v2/spaces/%s/custom-content?limit=250", spaceID))
+	if err != nil {
+		return nil, fmt.Errorf("fetch custom content for space %s: %w", spaceID, err)
+	}
+	return items, nil
+}
+
+// smartContentTypes are v2 content types without list endpoints — they are
+// discovered per space via CQL search, then fetched individually by ID.
+// Maps CQL type name → v2 URL path segment.
+var smartContentTypes = map[string]string{
+	"whiteboard": "whiteboards",
+	"database":   "databases",
+	"folder":     "folders",
+	"embed":      "embeds",
+}
+
+// SmartContentTypes returns the discoverable content types in stable order.
+func SmartContentTypes() []string {
+	return []string{"whiteboard", "database", "folder", "embed"}
+}
+
+// searchMaxPages bounds v1 search pagination (250 items/page → 10k items).
+const searchMaxPages = 40
+
+// FetchContentIDsByType discovers content of a given type (whiteboard,
+// database, folder, embed) in a space via the v1 CQL search API, which is
+// the documented way to enumerate these types — v2 has no list endpoints.
+func FetchContentIDsByType(ctx context.Context, client *Client, spaceKey, contentType string) ([]ContentRef, error) {
+	if _, ok := smartContentTypes[contentType]; !ok {
+		return nil, fmt.Errorf("unsupported content type %q", contentType)
+	}
+	var refs []ContentRef
+	cql := url.QueryEscape(fmt.Sprintf("space = %q and type = %s", spaceKey, contentType))
+	for page := 0; page < searchMaxPages; page++ {
+		body, err := client.Get(ctx, fmt.Sprintf(
+			"/wiki/rest/api/search?cql=%s&limit=250&start=%d", cql, page*250))
+		if err != nil {
+			return refs, fmt.Errorf("search %s in space %s: %w", contentType, spaceKey, err)
+		}
+		var resp struct {
+			Results []struct {
+				Content ContentRef `json:"content"`
+			} `json:"results"`
+			Size int `json:"size"`
+		}
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return refs, fmt.Errorf("parse search results for %s in space %s: %w", contentType, spaceKey, err)
+		}
+		for _, r := range resp.Results {
+			if r.Content.ID != "" {
+				refs = append(refs, r.Content)
+			}
+		}
+		if len(resp.Results) < 250 {
+			break
+		}
+	}
+	return refs, nil
+}
+
+// FetchContentItem fetches a single whiteboard, database, folder, or embed
+// by ID. The v2 API exposes metadata only for these types (no exportable
+// body), so the full payload is kept as raw JSON.
+func FetchContentItem(ctx context.Context, client *Client, contentType, id string) (json.RawMessage, error) {
+	segment, ok := smartContentTypes[contentType]
+	if !ok {
+		return nil, fmt.Errorf("unsupported content type %q", contentType)
+	}
+	body, err := client.Get(ctx, fmt.Sprintf("/wiki/api/v2/%s/%s", segment, url.PathEscape(id)))
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s %s: %w", contentType, id, err)
+	}
+	return json.RawMessage(body), nil
 }
 
 // FetchUserProfile fetches a single user profile by account ID (v1 API).

--- a/internal/api/confluence_test.go
+++ b/internal/api/confluence_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -191,5 +192,117 @@ func TestValidateDomain(t *testing.T) {
 	}
 	if err := api.ValidateDomain("bad domain!"); err == nil {
 		t.Error("invalid domain accepted")
+	}
+}
+
+func TestFetchSpaceLabels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var results []map[string]any
+		switch r.URL.Path {
+		case "/wiki/api/v2/spaces/42/labels":
+			results = []map[string]any{{"id": "l1", "name": "team", "prefix": "global"}}
+		case "/wiki/api/v2/spaces/42/content/labels":
+			results = []map[string]any{{"id": "l2", "name": "howto", "prefix": "global"}}
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"results": results, "_links": map[string]any{}})
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(srv.URL, "u@example.com", "tok")
+	labels, err := api.FetchSpaceLabels(context.Background(), c, "42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(labels.Space) != 1 || labels.Space[0].Name != "team" {
+		t.Errorf("unexpected space labels: %+v", labels.Space)
+	}
+	if len(labels.Content) != 1 || labels.Content[0].Name != "howto" {
+		t.Errorf("unexpected content labels: %+v", labels.Content)
+	}
+}
+
+func TestFetchTasks_FiltersBySpace(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"id": "7", "status": "incomplete", "pageId": "p1",
+					"body": map[string]any{"storage": map[string]any{"value": "<p>Do it</p>"}}},
+			},
+			"_links": map[string]any{},
+		})
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(srv.URL, "u@example.com", "tok")
+	tasks, err := api.FetchTasks(context.Background(), c, "42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotQuery, "space-id=42") {
+		t.Errorf("expected space-id filter in query, got: %s", gotQuery)
+	}
+	if len(tasks) != 1 || tasks[0].Status != "incomplete" || tasks[0].Body.Storage.Value != "<p>Do it</p>" {
+		t.Errorf("unexpected tasks: %+v", tasks)
+	}
+}
+
+func TestFetchContentIDsByType_UsesCQLSearch(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/wiki/rest/api/search") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		gotQuery, _ = url.QueryUnescape(r.URL.RawQuery)
+		json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"content": map[string]any{"id": "wb1", "type": "whiteboard", "title": "Brainstorm"}},
+			},
+			"size": 1,
+		})
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(srv.URL, "u@example.com", "tok")
+	refs, err := api.FetchContentIDsByType(context.Background(), c, "KB", "whiteboard")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotQuery, `space = "KB" and type = whiteboard`) {
+		t.Errorf("unexpected CQL query: %s", gotQuery)
+	}
+	if len(refs) != 1 || refs[0].ID != "wb1" || refs[0].Title != "Brainstorm" {
+		t.Errorf("unexpected refs: %+v", refs)
+	}
+}
+
+func TestFetchContentIDsByType_RejectsUnknownType(t *testing.T) {
+	c := api.NewClient("https://example.invalid", "u@example.com", "tok")
+	if _, err := api.FetchContentIDsByType(context.Background(), c, "KB", "page"); err == nil {
+		t.Error("expected error for unsupported content type")
+	}
+}
+
+func TestFetchContentItem_UsesV2Endpoint(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		json.NewEncoder(w).Encode(map[string]any{"id": "db9", "title": "Inventory"})
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(srv.URL, "u@example.com", "tok")
+	item, err := api.FetchContentItem(context.Background(), c, "database", "db9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/wiki/api/v2/databases/db9" {
+		t.Errorf("expected /wiki/api/v2/databases/db9, got: %s", gotPath)
+	}
+	if !strings.Contains(string(item), "Inventory") {
+		t.Errorf("unexpected item payload: %s", item)
 	}
 }

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -237,10 +237,84 @@ func processSpace(ctx context.Context, client *api.Client, w *storage.Writer,
 		}
 	}
 
+	// Labels, tasks, custom content, and smart content (whiteboards,
+	// databases, folders, embeds) — all non-critical: log and continue.
+	if !cfg.DryRun {
+		writeSpaceExtras(ctx, client, w, manifest, sp)
+	}
+
 	if len(pageErrs) > 0 {
 		return fmt.Errorf("%d page(s) failed", len(pageErrs))
 	}
 	return nil
+}
+
+// writeSpaceExtras backs up labels, inline tasks, custom content, and smart
+// content types (whiteboards, databases, folders, embeds) for one space.
+// All fetches are non-critical — failures are logged, the backup continues.
+func writeSpaceExtras(ctx context.Context, client *api.Client, w *storage.Writer,
+	manifest *Manifest, sp api.Space) {
+
+	writeJSON := func(relPath string, v any) {
+		data, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			slog.Warn("marshal failed", "path", relPath, "err", err)
+			return
+		}
+		if err := w.WriteFile(relPath, data); err != nil {
+			slog.Warn("write failed", "path", relPath, "err", err)
+			return
+		}
+		if err := manifest.AddFile(filepath.Join(w.Dir(), relPath)); err != nil {
+			slog.Warn("manifest update failed", "path", relPath, "err", err)
+		}
+	}
+
+	// Labels (space-level + content labels)
+	if labels, err := api.FetchSpaceLabels(ctx, client, sp.ID); err != nil {
+		slog.Warn("labels fetch failed", "space", sanitizeLog(sp.Key), "err", err)
+	} else if len(labels.Space) > 0 || len(labels.Content) > 0 {
+		writeJSON(filepath.Join("spaces", sp.Key, "labels.json"), labels)
+	}
+
+	// Inline tasks
+	if tasks, err := api.FetchTasks(ctx, client, sp.ID); err != nil {
+		slog.Warn("tasks fetch failed", "space", sanitizeLog(sp.Key), "err", err)
+	} else if len(tasks) > 0 {
+		writeJSON(filepath.Join("spaces", sp.Key, "tasks.json"), tasks)
+	}
+
+	// Custom content (app-defined types, raw JSON)
+	if custom, err := api.FetchCustomContent(ctx, client, sp.ID); err != nil {
+		slog.Warn("custom content fetch failed", "space", sanitizeLog(sp.Key), "err", err)
+	} else if len(custom) > 0 {
+		writeJSON(filepath.Join("spaces", sp.Key, "custom-content.json"), custom)
+	}
+
+	// Whiteboards, databases, folders, embeds — discovered via CQL search
+	// (v2 has no list endpoints for these), then fetched by ID. The v2 API
+	// exposes metadata only; whiteboard/database contents are not exportable.
+	for _, contentType := range api.SmartContentTypes() {
+		refs, err := api.FetchContentIDsByType(ctx, client, sp.Key, contentType)
+		if err != nil {
+			slog.Warn("content discovery failed",
+				"space", sanitizeLog(sp.Key), "type", contentType, "err", err)
+			continue
+		}
+		for _, ref := range refs {
+			item, err := api.FetchContentItem(ctx, client, contentType, ref.ID)
+			if err != nil {
+				slog.Warn("content fetch failed",
+					"space", sanitizeLog(sp.Key), "type", contentType, "id", ref.ID, "err", err)
+				continue
+			}
+			name := ref.ID
+			if ref.Title != "" {
+				name += "_" + storage.SanitizeName(ref.Title)
+			}
+			writeJSON(filepath.Join("spaces", sp.Key, contentType+"s", name+".json"), item)
+		}
+	}
 }
 
 func writePage(ctx context.Context, client *api.Client, w *storage.Writer,

--- a/scripts/check-api-schema.sh
+++ b/scripts/check-api-schema.sh
@@ -58,17 +58,26 @@ def deref(spec, obj, depth=0):
         depth += 1
     return obj
 
+def props_of(spec, schema, depth=0):
+    """Resolve a schema to its property map, merging allOf members."""
+    if depth > 10:
+        return {}
+    schema = deref(spec, schema)
+    props = dict(schema.get("properties", {}))
+    for member in schema.get("allOf", []):
+        props.update(props_of(spec, member, depth + 1))
+    return props
+
 def fields(spec, path):
     item = spec.get("paths", {}).get(path)
     if not item or "get" not in item:
         return ["__ENDPOINT_MISSING__"]
     try:
-        schema = deref(spec, item["get"]["responses"]["200"]["content"]["application/json"]["schema"])
-        props = schema.get("properties", {})
+        schema = item["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+        props = props_of(spec, schema)
         # List endpoints wrap items in {results: [...], _links: {...}}
         if "results" in props:
-            items = deref(spec, deref(spec, props["results"]).get("items", {}))
-            props = items.get("properties", {})
+            props = props_of(spec, deref(spec, props["results"]).get("items", {}))
         return sorted(props.keys()) or ["__SCHEMA_UNPARSEABLE__"]
     except (KeyError, TypeError):
         return ["__SCHEMA_UNPARSEABLE__"]
@@ -83,9 +92,18 @@ ENDPOINTS = {
     "page_footer_comments":  ("v2", "/pages/{id}/footer-comments"),
     "page_inline_comments":  ("v2", "/pages/{id}/inline-comments"),
     "space_properties":      ("v2", "/spaces/{space-id}/properties"),
+    "space_labels":          ("v2", "/spaces/{id}/labels"),
+    "space_content_labels":  ("v2", "/spaces/{id}/content/labels"),
+    "space_custom_content":  ("v2", "/spaces/{id}/custom-content"),
+    "tasks":                 ("v2", "/tasks"),
+    "whiteboard":            ("v2", "/whiteboards/{id}"),
+    "database":              ("v2", "/databases/{id}"),
+    "folder":                ("v2", "/folders/{id}"),
+    "embed":                 ("v2", "/embeds/{id}"),
     "templates_page_v1":     ("v1", "/wiki/rest/api/template/page"),
     "templates_blueprint_v1": ("v1", "/wiki/rest/api/template/blueprint"),
     "user_v1":               ("v1", "/wiki/rest/api/user"),
+    "search_v1":             ("v1", "/wiki/rest/api/search"),
 }
 
 specs = {"v2": v2, "v1": v1}


### PR DESCRIPTION
Erweitert das Backup von 8 auf 12 Confluence-Datentypen:

| Neu | Endpoint | Output |
|-----|----------|--------|
| Labels (Space + Content) | `/spaces/{id}/labels`, `/spaces/{id}/content/labels` | `spaces/KEY/labels.json` |
| Inline-Tasks | `/tasks?space-id=` | `spaces/KEY/tasks.json` |
| Custom Content | `/spaces/{id}/custom-content` | `spaces/KEY/custom-content.json` |
| Whiteboards / Databases / Folders / Embeds | CQL-Discovery + `/{type}s/{id}` | `spaces/KEY/{type}s/{id}_{titel}.json` |

**Design-Entscheide:**
- Whiteboards & Co. haben **keine v2-Listen-Endpoints** — Discovery läuft über die dokumentierte v1-CQL-Suche (`space = "KEY" and type = whiteboard`), Details dann per ID via v2. Die API liefert für diese Typen **nur Metadaten** (Canvas-/Datenbankinhalte sind nicht exportierbar) — dokumentiert in CLAUDE.md.
- Alle neuen Fetches sind non-fatal (warn + continue), Dateien werden nur bei Inhalt geschrieben.
- Drift-Check: jetzt 20 überwachte Endpoints (inkl. CQL-Search); Schema-Extraktor versteht `allOf`-Komposition (nötig für die neuen Typen). Baseline regeneriert, Stabilität lokal verifiziert.

Tests: 5 neue Unit-Tests, Suite lokal grün (ausser bekanntem Windows-Permission-Test).

Label `api-drift` → Merge triggert auto-release (v0.5.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)