### PR TITLE
ci: reife Dependabot-PRs automatisch mergen (7-Tage-Cooldown)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,17 +3,23 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: Europe/Zurich
     open-pull-requests-limit: 5
+    # Supply-chain maturity window: adopt a release only after it has been
+    # public for a week, so a compromised or yanked version is likely caught
+    # before it is merged. Applies to version updates only — security
+    # advisories bypass the cooldown and are proposed immediately.
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: Europe/Zurich
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,40 @@
+name: dependabot-auto-merge
+
+# Auto-merges Dependabot PRs once their required CI checks pass. The supply-chain
+# maturity window is enforced upstream by `cooldown` in dependabot.yml — a bump
+# is only opened ~7 days after the release. Major version bumps are NOT
+# auto-merged (possible breaking changes) and stay open for human review.
+#
+# `gh pr merge --auto` respects the main-protection ruleset: the merge completes
+# only after the required status checks (build matrix, security-and-quality,
+# dependency-review) pass.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3
+
+      - name: Enable auto-merge for non-major updates
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Flag major updates for manual review
+        if: steps.meta.outputs.update-type == 'version-update:semver-major' && github.event.action == 'opened'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "$PR_URL" --body "Major version update — not auto-merged. Review for breaking changes, then merge manually."


### PR DESCRIPTION
Setzt um, dass Dependency-Bumps nach einer Reifezeit automatisch gemerged werden.

## Zwei native Mechanismen
1. **`cooldown: default-days: 7`** in `dependabot.yml` — ein Bump wird erst **7 Tage nach Release** vorgeschlagen (an das echte Release-Datum gekoppelt). Fängt kompromittierte/zurückgezogene Versionen ab, bevor sie gemerged werden. **Security-Advisories umgehen den Cooldown** (sofort).
2. **`interval: daily`** (war wöchentlich) — sobald die Reifezeit um ist, wird der PR beim nächsten täglichen Check geöffnet.
3. **`dependabot-auto-merge.yml`** — merged **Patch/Minor automatisch**, sobald die Pflicht-CI grün ist (`gh pr merge --auto` wartet via Ruleset auf build + checks + dependency-review). **Major-Bumps bleiben offen** für manuelle Review (Breaking-Change-Risiko) und bekommen einen Hinweis-Kommentar.

## Best-Practice-Begründung
Die Reifezeit ist die Standard-Mitigation gegen Supply-Chain-Angriffe (kompromittierte Version wird meist binnen Stunden–Tagen entdeckt). 3 Tage = unterer Rand, 7 Tage = konservativer Standard. Über `default-days` mit einer Zeile anpassbar.

Sicherheit bleibt gewahrt: dependency-review (Lizenz-Allowlist + CVE-Gate) und die volle CI müssen **vor** dem Auto-Merge grün sein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)