### PR TITLE
Restrict release workflow to least-privilege permissions (#25)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,11 @@ on:
     tags:
       - 'v*'
 
+# Least privilege (issue #25): the workflow grants nothing by default; each
+# job below declares only the permissions it needs. In particular the build
+# jobs do NOT get contents:write — only the release job does.
 permissions:
-  contents: write
-  actions: read
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   # Security gate: every release runs the full security check suite AND is
@@ -72,6 +72,11 @@ jobs:
   build:
     name: Build ${{ matrix.artifact }}
     needs: security-gate
+    # Build needs OIDC for provenance attestation — but NOT contents:write.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       matrix:
         include:
@@ -121,6 +126,10 @@ jobs:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    # Only this job writes to the repo (creates the Release); id-token for cosign.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
## Summary

The release workflow declared broad **top-level** permissions that applied to **every** job:

```yaml
permissions:
  contents: write
  actions: read
  id-token: write
  attestations: write
```

But only the `release` job needs `contents: write`, and only the `build` jobs need `id-token`/`attestations`. This is the least-privilege finding (#25) already fixed in the sister repo **holaspirit-backup**.

## Changes

- **Top-level**: reduced to `contents: read` (grant nothing by default).
- **build** job: scoped to `contents: read`, `id-token: write`, `attestations: write`.
- **release** job: scoped to `contents: write`, `id-token: write`.
- **security-gate** job: unchanged (already `contents: read`, `issues: read`).

Mirrors the corresponding fix on `main` in holaspirit-backup.

## Validation

- `npx -y js-yaml .github/workflows/release.yml` → parses OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)