### PR TITLE
fix: UTF-16LE Windows-Credential dekodieren (ungültiger Authorization-Header)

### DIFF
--- a/cmd/backup/credblob.go
+++ b/cmd/backup/credblob.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"unicode/utf16"
+)
+
+// decodeCredentialBlob converts a Windows Credential Manager blob to a string.
+// `cmdkey` stores passwords as UTF-16LE, so reading the raw blob as a Go string
+// leaves a NUL byte after every ASCII character — which makes an invalid HTTP
+// Authorization header. Decode UTF-16LE when the blob looks like it (even
+// length with embedded NULs); otherwise treat it as a plain UTF-8 string.
+// Surrounding whitespace/newlines are trimmed either way.
+//
+// This lives in a platform-neutral file (no build tag) so it is compiled and
+// unit-tested on the Linux CI, even though its only caller is Windows-only.
+func decodeCredentialBlob(b []byte) string {
+	hasNUL := false
+	for _, c := range b {
+		if c == 0 {
+			hasNUL = true
+			break
+		}
+	}
+	if len(b)%2 == 0 && hasNUL {
+		u16 := make([]uint16, len(b)/2)
+		for i := range u16 {
+			u16[i] = uint16(b[2*i]) | uint16(b[2*i+1])<<8 // little-endian
+		}
+		return strings.TrimSpace(string(utf16.Decode(u16)))
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/cmd/backup/credblob_test.go
+++ b/cmd/backup/credblob_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"unicode/utf16"
+	"testing"
+)
+
+func utf16le(s string) []byte {
+	u := utf16.Encode([]rune(s))
+	b := make([]byte, len(u)*2)
+	for i, v := range u {
+		b[2*i] = byte(v)
+		b[2*i+1] = byte(v >> 8)
+	}
+	return b
+}
+
+func TestDecodeCredentialBlob(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{"utf16le token (cmdkey)", utf16le("ATSTT-abc123"), "ATSTT-abc123"},
+		{"utf16le with trailing newline", utf16le("ATSTT-abc123\n"), "ATSTT-abc123"},
+		{"plain utf8", []byte("ATATT-xyz789"), "ATATT-xyz789"},
+		{"plain utf8 with whitespace", []byte("  ATATT-xyz789\r\n"), "ATATT-xyz789"},
+		{"empty", []byte{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := decodeCredentialBlob(tt.in); got != tt.want {
+				t.Errorf("decodeCredentialBlob(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeCredentialBlob_NoNULsLeftForHeader(t *testing.T) {
+	// Regression: a UTF-16LE blob must not yield a string containing NUL bytes,
+	// which made an invalid HTTP Authorization header.
+	got := decodeCredentialBlob(utf16le("ATSTT-token"))
+	for i := 0; i < len(got); i++ {
+		if got[i] == 0 {
+			t.Fatalf("decoded token still contains a NUL byte at %d", i)
+		}
+	}
+}

--- a/cmd/backup/token_windows.go
+++ b/cmd/backup/token_windows.go
@@ -24,7 +24,7 @@ func getCredentials() (credentials, error) {
 		if err != nil {
 			return credentials{}, fmt.Errorf("CONFLUENCE_TOKEN not set and credential not found in Windows Credential Manager (target: confluence-backup): %w", err)
 		}
-		token = string(cred.CredentialBlob)
+		token = decodeCredentialBlob(cred.CredentialBlob)
 	}
 	email := os.Getenv("CONFLUENCE_EMAIL")
 	if email != "" {


### PR DESCRIPTION
**Beim lokalen Backup-Test gegen eine echte Instanz gefunden.**

`cmdkey` speichert Credentials als **UTF-16LE**. `token_windows.go` las den rohen Blob mit `string(cred.CredentialBlob)` — dadurch blieb nach jedem ASCII-Zeichen ein `\x00`-Byte stehen, und Gos HTTP-Client lehnte den `Authorization`-Header mit `invalid header field value` ab. Backup über den Windows Credential Manager war damit faktisch kaputt.

Diagnose am echten Token: `blob_len=384, null_bytes=192` → klar UTF-16LE.

## Fix
- `credblob.go`: plattformneutrale `decodeCredentialBlob()` — UTF-16LE-Dekodierung bei eingebetteten NULs, sonst Plain-UTF-8; trimmt umgebenden Whitespace. **Ohne Build-Tag**, damit die Linux-CI sie kompiliert und testet (der Windows-Token-Pfad lief vorher nie in der CI).
- `credblob_test.go`: UTF-16LE, trailing Newline, Plain-UTF-8, NUL-frei-Regression.
- `token_windows.go`: ruft `decodeCredentialBlob()` statt `string()`.

Nach dem Fix wird der Header korrekt gesendet (verifiziert: 401 vom Server statt Header-Fehler — der verbleibende 401 ist ein separates Scope-Problem des Service-Account-Tokens, kein Tool-Bug).

Hinweis: derselbe Bug existiert in holaspirit-backup (`internal/credentials/wincred.go`) — wird separat gespiegelt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)