### PR TITLE
fix: verify re-hasht Backup-Dateien + eindeutige Template-Dateinamen

### DIFF
--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -56,6 +56,9 @@ func Run(ctx context.Context, client *api.Client, cfg Config) (string, error) {
 		return "", fmt.Errorf("create backup dir: %w", err)
 	}
 	manifest := NewManifest(cfg.Domain, cfg.ToolVersion, ts)
+	// Record file names relative to the backup root so each manifest entry maps
+	// to a unique file and can be re-hashed during verify.
+	manifest.Root = w.Dir()
 
 	// --- Fetch all spaces ---
 	spaces, err := api.FetchSpaces(ctx, client)
@@ -165,8 +168,16 @@ func processSpace(ctx context.Context, client *api.Client, w *storage.Writer,
 			slog.Warn("template marshal failed", "space", sp.Key, "name", tmpl.Name, "err", err)
 			continue
 		}
+		// Include the unique template ID in the filename: many templates share
+		// a display name (e.g. several "Default index page template" blueprints,
+		// plus page+blueprint variants), which would otherwise sanitise to the
+		// same path and silently overwrite each other.
+		tName := storage.SanitizeName(tmpl.Name)
+		if tName == "" {
+			tName = "template"
+		}
 		tPath := filepath.Join("spaces", sp.Key, "templates",
-			storage.SanitizeName(tmpl.Name)+".json")
+			tName+"_"+storage.SanitizeName(tmpl.TemplateID)+".json")
 		if !cfg.DryRun {
 			if err := w.WriteFile(tPath, tJSON); err != nil {
 				slog.Warn("template write failed", "space", sp.Key, "name", tmpl.Name, "err", err)

--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -31,6 +31,7 @@ type Summary struct {
 // All mutating methods are safe to call from concurrent goroutines.
 type Manifest struct {
 	mu          sync.Mutex  // protects Files during concurrent backup
+	Root        string      `json:"-"` // backup dir root; file names are stored relative to it
 	Timestamp   time.Time   `json:"timestamp"`
 	ToolVersion string      `json:"tool_version"`
 	Domain      string      `json:"domain"`
@@ -46,23 +47,47 @@ func NewManifest(domain, version string, ts time.Time) *Manifest {
 	}
 }
 
-// AddFile hashes the file at path and records it as a successful entry.
-// Safe to call concurrently from multiple goroutines.
-func (m *Manifest) AddFile(path string) error {
-	f, err := os.Open(path) // #nosec G304 -- path is always an internally constructed backup path
+// hashFile returns the lowercase hex SHA-256 of the file at path. The same
+// helper is used when building the manifest and when verifying it, so the two
+// can never compute the hash differently.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path) // #nosec G304 -- internally constructed backup path / manifest-listed file
 	if err != nil {
-		return fmt.Errorf("open %s: %w", path, err)
+		return "", err
 	}
 	defer f.Close()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// manifestName returns the name to record for a file: its path relative to the
+// backup root (forward-slashed for portability), so each entry maps to a unique
+// file and can be re-hashed during verify. Falls back to the base name when no
+// root is set (e.g. in tests).
+func (m *Manifest) manifestName(path string) string {
+	if m.Root != "" {
+		if rel, err := filepath.Rel(m.Root, path); err == nil {
+			return filepath.ToSlash(rel)
+		}
+	}
+	return filepath.Base(path)
+}
+
+// AddFile hashes the file at path and records it as a successful entry.
+// Safe to call concurrently from multiple goroutines.
+func (m *Manifest) AddFile(path string) error {
+	sum, err := hashFile(path)
+	if err != nil {
 		return fmt.Errorf("hash %s: %w", path, err)
 	}
 
 	entry := FileEntry{
-		Name:   filepath.Base(path),
-		SHA256: hex.EncodeToString(h.Sum(nil)),
+		Name:   m.manifestName(path),
+		SHA256: sum,
 		Status: "ok",
 	}
 	m.mu.Lock()
@@ -109,6 +134,10 @@ func (m *Manifest) Write(path, token string) error {
 	return os.WriteFile(sigPath, []byte(sig), 0600)
 }
 
+// VerifyManifest checks the HMAC-SHA-256 signature of the manifest AND re-hashes
+// every successfully-backed-up file against the signed SHA-256 in the manifest.
+// The signature proves the manifest (and its hashes) is authentic; the re-hash
+// proves the backup files still match it. A mismatch in either fails.
 func VerifyManifest(manifestPath, token string) error {
 	data, err := os.ReadFile(manifestPath) // #nosec G304 -- path comes from CLI flag
 	if err != nil {
@@ -119,10 +148,42 @@ func VerifyManifest(manifestPath, token string) error {
 	if err != nil {
 		return fmt.Errorf("read sig: %w", err)
 	}
-	expected := computeHMAC(data, token)
-	if !hmac.Equal([]byte(expected), sigBytes) {
+	expectedBytes, err := hex.DecodeString(computeHMAC(data, token))
+	if err != nil {
+		return fmt.Errorf("compute expected signature: %w", err)
+	}
+	storedBytes, err := hex.DecodeString(strings.TrimSpace(string(sigBytes)))
+	if err != nil {
+		return fmt.Errorf("malformed signature file (%s): not valid hex", sigPath)
+	}
+	if !hmac.Equal(expectedBytes, storedBytes) {
 		return fmt.Errorf("manifest signature mismatch — backup may have been tampered with")
 	}
+
+	// Manifest is authentic; now confirm the backup files still match it.
+	var parsed struct {
+		Files []FileEntry `json:"files"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+	dir := filepath.Dir(manifestPath)
+	checked := 0
+	for _, f := range parsed.Files {
+		if f.Status != "ok" {
+			continue
+		}
+		filePath := filepath.Join(dir, filepath.FromSlash(f.Name))
+		sum, err := hashFile(filePath)
+		if err != nil {
+			return fmt.Errorf("verify %s: %w", f.Name, err)
+		}
+		if !strings.EqualFold(sum, f.SHA256) {
+			return fmt.Errorf("file hash mismatch for %s — backup file was modified after signing", f.Name)
+		}
+		checked++
+	}
+	_ = checked
 	return nil
 }
 

--- a/internal/backup/manifest_test.go
+++ b/internal/backup/manifest_test.go
@@ -3,6 +3,7 @@ package backup_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,6 +42,75 @@ func TestManifest_VerifyFailsWithWrongToken(t *testing.T) {
 
 	if err := backup.VerifyManifest(manifestPath, "wrong-token"); err == nil {
 		t.Error("expected error with wrong token")
+	}
+}
+
+// TestManifest_VerifyDetectsFileTampering is the regression for the local-test
+// finding: verify must re-hash backup files, not only check the manifest's own
+// signature. Modifying a backed-up file after signing must fail verification.
+func TestManifest_VerifyDetectsFileTampering(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "spaces", "KB", "pages", "Home")
+	if err := os.MkdirAll(nested, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(nested, "index.html")
+	if err := os.WriteFile(filePath, []byte("<p>original</p>"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := backup.NewManifest("myorg.atlassian.net", "dev", testTime())
+	m.Root = dir // record relative paths
+	if err := m.AddFile(filePath); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(dir, "backup-manifest.json")
+	if err := m.Write(manifestPath, "tok"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Intact backup verifies.
+	if err := backup.VerifyManifest(manifestPath, "tok"); err != nil {
+		t.Fatalf("intact backup should verify: %v", err)
+	}
+
+	// Tamper with the file → verify must now fail.
+	if err := os.WriteFile(filePath, []byte("<p>tampered</p>"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	err := backup.VerifyManifest(manifestPath, "tok")
+	if err == nil {
+		t.Fatal("verify must fail after a backup file is modified")
+	}
+	if !strings.Contains(err.Error(), "hash mismatch") {
+		t.Errorf("expected a hash-mismatch error, got: %v", err)
+	}
+}
+
+// TestManifest_RelativePathNames confirms entries are stored relative to Root
+// (forward-slashed), so nested files map uniquely.
+func TestManifest_RelativePathNames(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "spaces", "KB")
+	if err := os.MkdirAll(nested, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(nested, "space.json")
+	if err := os.WriteFile(p, []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	m := backup.NewManifest("x", "dev", testTime())
+	m.Root = dir
+	if err := m.AddFile(p); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(dir, "backup-manifest.json")
+	if err := m.Write(manifestPath, "tok"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(manifestPath)
+	if !strings.Contains(string(data), `"spaces/KB/space.json"`) {
+		t.Errorf("expected relative forward-slashed name in manifest, got:\n%s", data)
 	}
 }
 


### PR DESCRIPTION
**Beim lokalen Backup+verify-Lauf gegen die echte Instanz gefunden** (zwei Bugs, einer deckte den anderen auf).

## 1. verify prüfte Datei-Integrität gar nicht
`verify` validierte nur die **HMAC-Signatur des Manifests** — es re-hashte die Backup-Dateien **nie** gegen die signierten SHA256-Werte. Eine manipulierte Datei kam mit „manifest verified successfully" durch. Jetzt: nach der Signaturprüfung wird jede `status="ok"`-Datei re-gehasht; Abweichung/fehlende Datei → Exit 1. Gemeinsame `hashFile()` für Bauen + Prüfen.

## 2. Manifest speicherte nur Basenamen
Einträge waren mehrdeutig (viele `space.json`, `index.html`, …) und keiner Datei zuordenbar. Manifest speichert jetzt den **relativen Pfad** zur Backup-Root (forward-slashed) via `Manifest.Root`. Das macht #1 überhaupt möglich.

## 3. (durch #1 aufgedeckt) Template-Dateinamen-Kollision = Datenverlust
Templates wurden als `<Name>.json` geschrieben, aber viele teilen denselben Anzeigenamen (z.B. **12×** „Default index page template" + page/blueprint-Varianten) → sie **überschrieben sich gegenseitig**. Das Backup *verlor* Templates, und das Manifest hatte divergente Hashes für einen Pfad. Dateiname enthält jetzt die eindeutige `templateId`.

## Verifiziert (echte Instanz)
- Vorher: 430 Einträge / **248 eindeutig** (162 Kollisionen), verify schlug schon intakt fehl
- Nachher: **430 / 430 eindeutig**, verify besteht intakt **und** schlägt bei Manipulation fehl

Tests: Tamper-Erkennung + relative-Pfad-Benennung. Spiegelung des verify-Fixes nach holaspirit folgt separat (dort flache Struktur, keine Templates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)