### PR TITLE
docs: Service-Account-Auth (Bearer) + benötigte Confluence-Scopes dokumentieren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,12 @@ into a hierarchical directory structure with HMAC-SHA-256 signed manifest.
   - `CONFLUENCE_EMAIL` set → Basic Auth (`ATATT` token) against `https://{domain}/wiki/...`
   - No email → Bearer Auth (`ATSTT` service account token) via API Gateway:
     `https://api.atlassian.com/ex/confluence/{cloudID}/wiki/...`
+  - Service-account tokens need granular Confluence read scopes
+    (read:space/page/blogpost/space.permission/space.property/label/
+    custom-content/template/attachment/comment/task/whiteboard/database/
+    folder/embed/user:confluence + search:confluence) or the API returns
+    `401 "scope does not match"` — full list in README → Konfiguration
+  - Windows credential blob is UTF-16LE (cmdkey) — decoded in `cmd/backup/credblob.go`
 - **Cloud ID**: set `CONFLUENCE_CLOUD_ID` to skip auto-discovery (recommended; auto-discovery requires `read:me` scope)
 - **Space-scoped endpoints**: `/wiki/api/v2/spaces/{id}/pages` — avoids API Gateway filter bug
 - **Body format**: `storage` (Confluence native XML) — `view` not supported by API Gateway

--- a/README.md
+++ b/README.md
@@ -40,20 +40,52 @@ cosign verify-blob \
 
 ## Konfiguration
 
-**API-Token setzen:**
+Der Token wird aus `CONFLUENCE_TOKEN` (Umgebungsvariable) oder dem Windows
+Credential Manager (Ziel `confluence-backup`) gelesen:
 
 ```bash
 # Linux/macOS
-export CONFLUENCE_TOKEN=<Atlassian PAT>
+export CONFLUENCE_TOKEN=<Atlassian Token>
 
-# Windows (Credential Manager)
-cmdkey /generic:confluence-backup /user:api /pass:<Atlassian PAT>
+# Windows (Credential Manager) — Token wird als UTF-16 gespeichert und korrekt dekodiert
+cmdkey /generic:confluence-backup /user:api /pass:<Atlassian Token>
 ```
+
+### Authentifizierung: zwei Modi
+
+| Modus | Wann | Setup |
+|-------|------|-------|
+| **Basic Auth** (persönlicher Account) | `CONFLUENCE_EMAIL` gesetzt | Personal API Token (`ATATT…`) von [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) + `CONFLUENCE_EMAIL=<deine-atlassian-email>`. Erbt die Leserechte des Accounts — keine Scope-Konfiguration nötig. |
+| **Bearer Auth** (Service-Account) | keine `CONFLUENCE_EMAIL` | Service-Account-Token (`ATSTT…`) über das API-Gateway. `CONFLUENCE_CLOUD_ID` setzen (umgeht die `read:me`-Auto-Discovery; Cloud-ID via `https://<domain>/_edge/tenant_info`). |
+
+**Service-Account-Token — benötigte Scopes:** Der Token muss mit diesen
+granularen Confluence-Read-Scopes erstellt werden, sonst antwortet die API mit
+`401 "scope does not match"`:
+
+```
+read:space:confluence            read:attachment:confluence
+read:page:confluence             read:comment:confluence
+read:blogpost:confluence         read:task:confluence
+read:space.permission:confluence read:whiteboard:confluence
+read:space.property:confluence   read:database:confluence
+read:label:confluence            read:folder:confluence
+read:custom-content:confluence   read:embed:confluence
+read:template:confluence         read:user:confluence
+search:confluence
+```
+
+> Der Service-Account braucht zusätzlich **Leserechte auf die zu sichernden
+> Spaces** (Space Settings → Permissions). Fehlen einzelne Scopes, werden die
+> betroffenen Datentypen übersprungen (per-Endpoint non-fatal), der Rest läuft.
 
 **Backup ausführen:**
 
 ```bash
-confluence-backup --domain myorg.atlassian.net --output ./backups
+# Basic Auth (persönlicher Account)
+CONFLUENCE_EMAIL=me@example.com confluence-backup --domain myorg.atlassian.net --output ./backups
+
+# Bearer Auth (Service-Account)
+CONFLUENCE_CLOUD_ID=<uuid> confluence-backup --domain myorg.atlassian.net --output ./backups
 ```
 
 **Integrität prüfen:**


### PR DESCRIPTION
Folgt aus dem lokalen Test: Ein Service-Account-Token (ATSTT) ohne die passenden granularen Confluence-Read-Scopes antwortet mit `401 "scope does not match"`.

- **README → Konfiguration**: beide Auth-Modi sauber getrennt (Basic mit Personal-ATATT + `CONFLUENCE_EMAIL`; Bearer mit Service-Account-ATSTT + `CONFLUENCE_CLOUD_ID`), vollständige Liste der benötigten granularen Read-Scopes (autoritativ von Atlassians Scope-Doku), Hinweis auf nötige Space-Leserechte + Cloud-ID-Ermittlung via `tenant_info`.
- **CLAUDE.md**: Querverweis bei der Auth-Architektur + Notiz zur UTF-16LE-cmdkey-Dekodierung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)