### PR TITLE
Add id-token: write to api-update-check (OIDC)

### DIFF
--- a/.github/workflows/api-update-check.yml
+++ b/.github/workflows/api-update-check.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write  # claude-code-action authenticates via OIDC
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10


### PR DESCRIPTION
## Summary
The daily `api-update-check` has failed every run since ~2026-06-25 with:
> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

**Root cause:** the Claude adaptation step only runs when drift is detected. Atlassian changed its API schema on ~06-25, triggering the **first real drift** — so the step executed for the first time and hit the missing `id-token: write`. The permission gap was latent; until then the step was always skipped (no drift) and the job passed.

**Fix:** grant `id-token: write` on the `check` job (claude-code-action authenticates via OIDC).

## Note
There is currently **pending Atlassian API drift** that has not been adapted. After merge, the next run (or a manual `workflow_dispatch`) will let Claude adapt `internal/api/confluence.go` and open the api-drift PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)