### PR TITLE
fix: adapt to Confluence API drift (2026-06-30)

### DIFF
--- a/docs/api-snapshot.json
+++ b/docs/api-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-06-12T21:27:04Z",
+  "generated": "2026-06-30T20:09:05Z",
   "sources": {
     "v2": {
       "url": "openapi-v2.v3.json",
@@ -188,6 +188,7 @@
       "id",
       "key",
       "name",
+      "spaceOwnerId",
       "status",
       "type"
     ],


### PR DESCRIPTION
## Confluence API schema update

The daily API schema check found drift against the stored baseline.
Claude adapted `internal/api/confluence.go` to the changes; build and race tests passed.

### Drift
```diff
178a179
>     "spaceOwnerId",
```

Merging this PR triggers the auto-release workflow (api-drift label).
